### PR TITLE
Added simulator utility

### DIFF
--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -104,7 +104,12 @@ public struct TLPhotosPickerConfigure {
 public struct Platform {
     
     public static var isSimulator: Bool {
-        return TARGET_OS_SIMULATOR != 0 // Use this line in Xcode 7 or newer
+        // Refactor: Modernize isSimulator check using #if targetEnvironment(simulator)
+        #if targetEnvironment(simulator)
+            return true
+        #else
+            return false
+        #endif
     }
     
 }


### PR DESCRIPTION
Replaced the legacy _**C-style macro**_ (`TARGET_OS_SIMULATOR`) with the recommended _**conditional compilation directive**_ (`#if targetEnvironment(simulator)`).